### PR TITLE
Update create_utfgrids.py. Fixed broken aspects of python bindings styling in 3.x

### DIFF
--- a/create_utfgrids.py
+++ b/create_utfgrids.py
@@ -41,9 +41,11 @@ def create_utfgrids(shppath, minzoom, maxzoom, outdir, fields=None, layernum=0):
     # Since grids are `rendered` they need a style 
     s = mapnik.Style()
     r = mapnik.Rule()
-    polygon_symbolizer = mapnik.PolygonSymbolizer(mapnik.Color('#f2eff9'))
+    polygon_symbolizer = mapnik.PolygonSymbolizer()
+    polygon_symbolizer.fill = mapnik.Color('#f2eff9')
     r.symbols.append(polygon_symbolizer)
-    line_symbolizer = mapnik.LineSymbolizer(mapnik.Color('rgb(50%,50%,50%)'),0.1)
+    line_symbolizer = mapnik.LineSymbolizer()
+    line_symbolizer.fill = mapnik.Color('rgb(50%,50%,50%)')
     r.symbols.append(line_symbolizer)
     s.rules.append(r)
     m.append_style('My Style',s)


### PR DESCRIPTION
There was an api change between python binding in mapnik 2 and mapnik 3. See  https://github.com/mapnik/mapnik/issues/2324 and for a working demo https://github.com/mapnik/mapnik/blob/master/demo/python/rundemo.py .
