### PR TITLE
Fix outdated Mapnik syntax

### DIFF
--- a/create_utfgrids.py
+++ b/create_utfgrids.py
@@ -41,9 +41,12 @@ def create_utfgrids(shppath, minzoom, maxzoom, outdir, fields=None, layernum=0):
     # Since grids are `rendered` they need a style 
     s = mapnik.Style()
     r = mapnik.Rule()
-    polygon_symbolizer = mapnik.PolygonSymbolizer(mapnik.Color('#f2eff9'))
+    polygon_symbolizer = mapnik.PolygonSymbolizer()
+    polygon_symbolizer.fill = mapnik.Color('#f2eff9')
     r.symbols.append(polygon_symbolizer)
-    line_symbolizer = mapnik.LineSymbolizer(mapnik.Color('rgb(50%,50%,50%)'),0.1)
+    line_symbolizer = mapnik.LineSymbolizer()
+    line_symbolizer.stroke = mapnik.Color('rgb(50%,50%,50%)')
+    line_symbolizer.stroke_width = 0.1
     r.symbols.append(line_symbolizer)
     s.rules.append(r)
     m.append_style('My Style',s)


### PR DESCRIPTION
Using current code return an error similar to this issue https://github.com/mapnik/mapnik/issues/3258
The solution is also similar: instanciate a constructor without any parameter then assign attributes
See official examples https://github.com/mapnik/mapnik/blob/master/demo/python/rundemo.py